### PR TITLE
chore(ci): adopt notify-site reusable workflow and harden changelog caller

### DIFF
--- a/.github/workflows/notify-site.yml
+++ b/.github/workflows/notify-site.yml
@@ -1,24 +1,15 @@
-# Add this workflow to each kaiseki package repository as
-# `.github/workflows/notify-site.yml`.
+# Thin caller for the shared "Notify docs site" reusable workflow in
+# kaisekidev/.github (.github/workflows/notify-site.yml@v1).
 #
-# On every push to the repo's default branch (master or main) and on published
-# releases, it tells the kaiseki-site repo to rebuild, so the documentation site
-# always reflects the latest README / docs.
+# On every push to the default branch and on published releases, it asks the
+# kaiseki-site repo to rebuild so the docs site reflects the latest README/docs.
+# All action pins live in the reusable workflow, so there is nothing here for
+# Dependabot to bump.
 #
-# ── HOW IT AUTHENTICATES ────────────────────────────────────────────────────
-# It mints a short-lived token from the org's `kaiseki-doc-bot` GitHub App,
-# scoped to kaiseki-site, and POSTs a `package-updated` repository_dispatch to
-# kaiseki-site (whose deploy.yml listens for that event). No per-repo secret —
-# the only stored credential is the org-level App private key (APP_PRIVATE_KEY),
-# already shared with every repo for the changelog flow. App installation tokens
-# (unlike the Actions GITHUB_TOKEN) are allowed to trigger the downstream build.
-#
-# The job is guarded to the kaisekidev org, so forks — which can't read the org
-# secrets — don't run it and fail.
-#
-# Prerequisites (one-time, org-wide — already in place):
-#   - `kaiseki-doc-bot` App installed on all repos incl. kaiseki-site (contents: write).
-#   - `APP_ID` / `APP_PRIVATE_KEY` org secrets readable by all repos.
+# The reusable workflow mints a short-lived kaiseki-doc-bot App token scoped to
+# kaiseki-site, so the App + the APP_ID / APP_PRIVATE_KEY org secrets must be
+# available to the repo (already org-wide). They are forwarded EXPLICITLY below
+# (not `secrets: inherit`), so only those two secrets reach the reusable workflow.
 
 name: Notify docs site
 
@@ -33,26 +24,9 @@ permissions:
 
 jobs:
   notify:
-    runs-on: ubuntu-latest
-    # Skip on forks: the org secrets aren't available there, so the dispatch
-    # can't authenticate and the run would just fail.
+    # Forks can't read the org App secrets — skip there (matches the old copy-in).
     if: ${{ github.repository_owner == 'kaisekidev' }}
-    steps:
-      - name: Mint a token scoped to kaiseki-site
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: kaisekidev
-          repositories: kaiseki-site
-
-      - name: Dispatch rebuild of kaiseki-site
-        run: |
-          curl -fsSL --retry 3 --retry-all-errors -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
-            -H "Content-Type: application/json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/kaisekidev/kaiseki-site/dispatches \
-            -d '{"event_type":"package-updated","client_payload":{"repo":"${{ github.repository }}","sha":"${{ github.sha }}"}}'
+    uses: kaisekidev/.github/.github/workflows/notify-site.yml@v1
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,14 +1,16 @@
-# Thin caller for the shared "Update Changelog" reusable workflow.
+# Thin caller for the shared "Update Changelog" reusable workflow in
+# kaisekidev/.github (.github/workflows/update-changelog.yml@v1).
 #
-# On a published GitHub Release, the reusable workflow in kaisekidev/.github
-# updates CHANGELOG.md from the release notes and opens an auto-merging PR. All
-# the action pins live in that reusable workflow, so there is nothing here for
-# Dependabot to bump.
+# When a non-prerelease GitHub Release is published (the `released` event), the
+# reusable workflow updates CHANGELOG.md from the release notes and opens an
+# auto-merging PR. All the action pins live in that reusable workflow, so there
+# is nothing here for Dependabot to bump.
 #
-# `secrets: inherit` forwards the org APP_ID / APP_PRIVATE_KEY secrets, which the
-# reusable workflow uses to mint a short-lived kaiseki-doc-bot GitHub App token
-# (the org blocks the default GITHUB_TOKEN from opening PRs, so an App token is
-# required to open the changelog PR and trigger its checks).
+# The two secrets are forwarded EXPLICITLY (not `secrets: inherit`), so only the
+# org APP_ID / APP_PRIVATE_KEY reach the reusable workflow — it mints a
+# short-lived kaiseki-doc-bot GitHub App token from them (the org blocks the
+# default GITHUB_TOKEN from opening PRs, so an App token is required to open the
+# changelog PR and trigger its checks). The caller's own token stays read-only.
 #
 # One-time prerequisites (set once, org-wide):
 #   1. The kaiseki-doc-bot App (contents + pull-requests: write) can access the repo.
@@ -22,7 +24,12 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: read
+
 jobs:
   update:
     uses: kaisekidev/.github/.github/workflows/update-changelog.yml@v1
-    secrets: inherit
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Re-syncs this repo's .github workflow callers to the current org standard (config only — no code changes).

## Changes
- notify-site.yml→caller
- update-changelog.yml→hardened

## Why
- `notify-site.yml` becomes a thin caller of the shared reusable workflow, so the docs-site trigger's action pin is maintained centrally — nothing left here for Dependabot to bump.
- `update-changelog.yml` forwards only `APP_ID`/`APP_PRIVATE_KEY` (an explicit secrets map, not `secrets: inherit`) and pins a read-only `permissions:` block.

## Validation
- The standard CI checks run on this PR and must pass before it merges.